### PR TITLE
Add support to the extended STOI measure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Python implementation of STOI
 
-Implementation of the Short Term Objective Intelligibility measure
+Implementation of the classical and extended Short Term Objective Intelligibility measures
 
-Intelligibility measure which is highly correlated with the intelligibility of degraded speech signals, e.g., due to additive noise, single/multi-channel noise reduction, binary masking and vocoded speech as in CI simulations. The STOI-measure is intrusive, i.e., a function of the clean and degraded speech signals. STOI may be a good alternative to the speech intelligibility index (SII) or the speech transmission index (STI), when you are interested in the effect of nonlinear processing to noisy speech, e.g., noise reduction, binary masking algorithms, on speech intelligibility.
+Intelligibility measure which is highly correlated with the intelligibility of degraded speech signals, e.g., due to additive noise, single/multi-channel noise reduction, binary masking and vocoded speech as in CI simulations. The STOI-measure is intrusive, i.e., a function of the clean and degraded speech signals. STOI may be a good alternative to the speech intelligibility index (SII) or the speech transmission index (STI), when you are interested in the effect of nonlinear processing to noisy speech, e.g., noise reduction, binary masking algorithms, on speech intelligibility.   
 Description taken from [Cees Taal's website](http://www.ceestaal.nl/code/)
 
 
@@ -20,7 +20,7 @@ fs, clean = read('path/to/clean/audio')
 fs, den = read('path/to/denoised/audio')
 
 # Clean and den should have the same length, and be 1D
-d = stoi(clean, den, fs)
+d = stoi(clean, den, fs, extended=False)
 ```
 
 ### Matlab code & Testing
@@ -52,6 +52,11 @@ The method is based on audio signal sampled at 10kHz (this is not the problem), 
 
 ### References
 * [1] C.H.Taal, R.C.Hendriks, R.Heusdens, J.Jensen 'A Short-Time
-  Objective Intelligibility Measure for Time-Frequency Weighted Noisy Speech', ICASSP 2010, Texas, Dallas.
+  Objective Intelligibility Measure for Time-Frequency Weighted Noisy Speech',
+  ICASSP 2010, Texas, Dallas.
 * [2] C.H.Taal, R.C.Hendriks, R.Heusdens, J.Jensen 'An Algorithm for
-  Intelligibility Prediction of Time-Frequency Weighted Noisy Speech', IEEE Transactions on Audio, Speech, and Language Processing, 2011.
+  Intelligibility Prediction of Time-Frequency Weighted Noisy Speech',
+  IEEE Transactions on Audio, Speech, and Language Processing, 2011.
+* [3] J. Jensen and C. H. Taal, 'An Algorithm for Predicting the
+  Intelligibility of Speech Masked by Modulated Noise Maskers',
+  IEEE Transactions on Audio, Speech and Language Processing, 2016.

--- a/pystoi/stoi.py
+++ b/pystoi/stoi.py
@@ -40,7 +40,7 @@ def stoi(x, y, fs_sig, extended=False):
             Intelligibility Prediction of Time-Frequency Weighted Noisy Speech',
             IEEE Transactions on Audio, Speech, and Language Processing, 2011.
         [3] Jesper Jensen and Cees H. Taal, 'An Algorithm for Predicting the
-            Intelligibility of Speech Masked by Modulated Noise Maskers', 
+            Intelligibility of Speech Masked by Modulated Noise Maskers',
             IEEE Transactions on Audio, Speech and Language Processing, 2016.
     """
     if x.shape != y.shape:
@@ -75,7 +75,7 @@ def stoi(x, y, fs_sig, extended=False):
         if extended:
             x_n = utils.row_col_normalize(x_seg)
             y_n = utils.row_col_normalize(y_seg)
-            interm_meas[m-N] = np.sum(x_n.flatten(order='F') * y_n.flatten()) / N
+            interm_meas[m-N] = np.sum(x_n * y_n / N)
         else:
             alpha = np.sqrt(np.sum(np.square(x_seg), 1) / np.sum(np.square(y_seg), 1))
             a_y_seg = np.multiply(y_seg.transpose(), alpha).transpose()

--- a/pystoi/stoi.py
+++ b/pystoi/stoi.py
@@ -15,7 +15,7 @@ BETA = -15.                         # Lower SDR bound
 DYN_RANGE = 40                      # Speech dynamic range
 
 
-def stoi(x, y, fs_sig):
+def stoi(x, y, fs_sig, extended=False):
     """ Short term objective intelligibility
     Computes the STOI (See [1][2]) of a denoised signal compared to a
     clean signal, The output is expected to have a monotonic
@@ -26,6 +26,7 @@ def stoi(x, y, fs_sig):
         x : clean original speech
         y : denoised speech
         fs_sig : sampling rate of x and y
+        extended : Boolean, whether to use the extended STOI described in [3]
     # Returns
         Short time objective intelligibility measure between clean and denoised
         speech
@@ -38,6 +39,9 @@ def stoi(x, y, fs_sig):
         [2] C.H.Taal, R.C.Hendriks, R.Heusdens, J.Jensen 'An Algorithm for
             Intelligibility Prediction of Time-Frequency Weighted Noisy Speech',
             IEEE Transactions on Audio, Speech, and Language Processing, 2011.
+        [3] Jesper Jensen and Cees H. Taal, 'An Algorithm for Predicting the
+            Intelligibility of Speech Masked by Modulated Noise Maskers', 
+            IEEE Transactions on Audio, Speech and Language Processing, 2016.
     """
     if x.shape != y.shape:
         raise Exception('x and y should have the same length,' +
@@ -58,16 +62,25 @@ def stoi(x, y, fs_sig):
     for i in range(x_tob.shape[1]):
         x_tob[:, i] = np.sqrt(np.matmul(OBM, np.square(np.abs(x_spec[:, i]))))
         y_tob[:, i] = np.sqrt(np.matmul(OBM, np.square(np.abs(y_spec[:, i]))))
-    interm_meas = np.zeros((NUMBAND, x_tob.shape[1] - N + 1))
-    clip = 10**(-BETA/20)
+
+    if extended:
+        interm_meas = np.zeros((x_tob.shape[1] - N + 1, ))
+    else:
+        interm_meas = np.zeros((NUMBAND, x_tob.shape[1] - N + 1))
+        clip = 10**(-BETA/20)
 
     for m in range(N, x_tob.shape[1] + 1):
         x_seg = x_tob[:, m-N:m]
         y_seg = y_tob[:, m-N:m]
-        alpha = np.sqrt(np.sum(np.square(x_seg), 1) / np.sum(np.square(y_seg), 1))
-        a_y_seg = np.multiply(y_seg.transpose(), alpha).transpose()
-        for j in range(NUMBAND):
-            Y_prime = np.minimum(a_y_seg[j, :], x_seg[j, :] * (1 + clip))
-            interm_meas[j, m-N] = utils.corr(x_seg[j, :], Y_prime[:])
+        if extended:
+            x_n = utils.row_col_normalize(x_seg)
+            y_n = utils.row_col_normalize(y_seg)
+            interm_meas[m-N] = np.sum(x_n.flatten(order='F') * y_n.flatten()) / N
+        else:
+            alpha = np.sqrt(np.sum(np.square(x_seg), 1) / np.sum(np.square(y_seg), 1))
+            a_y_seg = np.multiply(y_seg.transpose(), alpha).transpose()
+            for j in range(NUMBAND):
+                Y_prime = np.minimum(a_y_seg[j, :], x_seg[j, :] * (1 + clip))
+                interm_meas[j, m-N] = utils.corr(x_seg[j, :], Y_prime[:])
     d = np.mean(interm_meas)
     return d

--- a/pystoi/utils.py
+++ b/pystoi/utils.py
@@ -1,6 +1,7 @@
 import numpy as np
 import scipy
 
+EPS = np.finfo("float").eps
 
 def thirdoct(fs, nfft, num_bands, min_freq):
     """ Returns the 1/3 octave band matrix and its center frequencies
@@ -69,8 +70,7 @@ def remove_silent_frames(x, y, dyn_range, framelen, hop):
     """
     # Compute Mask
     w = scipy.hanning(framelen + 2)[1:-1]
-    mask = np.array([20 * np.log10(np.linalg.norm(w * x[i:i + framelen])
-                                   + np.finfo("float").eps)
+    mask = np.array([20 * np.log10(np.linalg.norm(w * x[i:i + framelen]) + EPS)
                      for i in range(0, len(x) - framelen, hop)])
     mask += dyn_range - np.max(mask)
     mask = mask > 0
@@ -99,3 +99,21 @@ def corr(x, y):
     new_y /= np.sqrt(np.sum(np.square(new_y)))
     rho = np.sum(new_x * new_y)
     return rho
+
+
+def vect_two_norm(x, axis=-1):
+    """ Returns a vectors of norms of the rows of a matrix """
+    return np.sum(np.square(x), axis=axis)
+
+
+def row_col_normalize(x):
+    """ Row and column mean and variance normalize a 2D matrix """
+    # Row mean and variance normalization
+    x_normed = x + EPS * np.random.standard_normal(x.shape)
+    x_normed -= np.mean(x_normed, axis=-1, keep_dims=True)
+    x_normed = np.matmul(np.diag(1. / np.sqrt(vect_two_norm(x_normed))), x_normed)
+    # Column mean and variance normalization
+    x_normed += + EPS * np.random.standard_normal(x_normed.shape)
+    x_normed -= np.mean(x_normed, axis=0, keep_dims=True)
+    x_normed = np.matmul(x_normed, np.diag(1. / np.sqrt(vect_two_norm(x_normed, axis=0))))
+    return x_normed

--- a/pystoi/utils.py
+++ b/pystoi/utils.py
@@ -110,10 +110,10 @@ def row_col_normalize(x):
     """ Row and column mean and variance normalize a 2D matrix """
     # Row mean and variance normalization
     x_normed = x + EPS * np.random.standard_normal(x.shape)
-    x_normed -= np.mean(x_normed, axis=-1, keep_dims=True)
+    x_normed -= np.mean(x_normed, axis=-1, keepdims=True)
     x_normed = np.matmul(np.diag(1. / np.sqrt(vect_two_norm(x_normed))), x_normed)
     # Column mean and variance normalization
     x_normed += + EPS * np.random.standard_normal(x_normed.shape)
-    x_normed -= np.mean(x_normed, axis=0, keep_dims=True)
+    x_normed -= np.mean(x_normed, axis=0, keepdims=True)
     x_normed = np.matmul(x_normed, np.diag(1. / np.sqrt(vect_two_norm(x_normed, axis=0))))
     return x_normed

--- a/tests/matlab/estoi.m
+++ b/tests/matlab/estoi.m
@@ -1,0 +1,191 @@
+function d = estoi(x, y, fs_signal)
+%   d = estoi(x, y, fs_signal) returns the output of the extended short-time
+%   objective intelligibility (ESTOI) predictor.
+%  
+% Implementation of the Extended Short-Time Objective
+% Intelligibility (ESTOI) predictor, described in Jesper Jensen and
+% Cees H. Taal, "An Algorithm for Predicting the Intelligibility of
+% Speech Masked by Modulated Noise Maskers," IEEE Transactions on
+% Audio, Speech and Language Processing, 2016.
+%
+% Input:
+%        x:         clean reference time domain signal
+%        y:         noisy/processed time domain signal
+%        fs_signal: sampling rate [Hz]
+%
+% Output:
+%        d: intelligibility index
+%
+%
+% Copyright 2016: Aalborg University, Section for Signal and Information Processing. 
+% The software is free for non-commercial use. 
+% The software comes WITHOUT ANY WARRANTY.
+
+
+if length(x)~=length(y)
+  error('x and y should have the same length');
+end
+
+% initialization
+x               = x(:);                   % clean speech column vector
+y               = y(:);                   % processed speech column vector
+
+fs              = 10000;                  % sample rate of proposed intelligibility measure
+N_frame         = 256;                    % window support
+K               = 512;                    % FFT size
+J               = 15;                     % Number of 1/3 octave bands
+mn              = 150;                    % Center frequency of first 1/3 octave band in Hz.
+[H,fc_thirdoct] = thirdoct(fs, K, J, mn); % Get 1/3 octave band matrix
+N               = 30;                     % Number of frames for intermediate intelligibility measure
+dyn_range       = 40;                     % speech dynamic range
+
+% resample signals if other samplerate is used than fs
+if fs_signal ~= fs
+  x	= resample(x, fs, fs_signal);
+  y 	= resample(y, fs, fs_signal);
+end
+
+% remove silent frames
+[x y] = removeSilentFrames(x, y, dyn_range, N_frame, N_frame/2);
+
+% apply 1/3 octave band TF-decomposition
+x_hat     	= stdft(x, N_frame, N_frame/2, K); % apply short-time DFT to clean speech
+y_hat     	= stdft(y, N_frame, N_frame/2, K); % apply short-time DFT to processed speech
+
+
+x_hat       = x_hat(:, 1:(K/2+1)).'; % take clean single-sided spectrum
+y_hat       = y_hat(:, 1:(K/2+1)).'; % take processed single-sided spectrum
+
+X           = zeros(J, size(x_hat, 2)); % init memory for clean speech 1/3 octave band TF-representation
+Y           = zeros(J, size(y_hat, 2)); % init memory for processed speech 1/3 octave band TF-representation
+
+for i = 1:size(x_hat, 2)
+  X(:, i)	= sqrt(H*abs(x_hat(:, i)).^2); % apply 1/3 octave band filtering
+  Y(:, i)	= sqrt(H*abs(y_hat(:, i)).^2);
+end
+
+% loop all segments of length N and obtain intermediate intelligibility measure for each
+d1 = zeros(length(N:size(X, 2)),1); % init memory for intermediate intelligibility measure
+for m=N:size(X,2)
+    X_seg  	= X(:, (m-N+1):m); % region of length N with clean TF-units for all j
+    Y_seg  	= Y(:, (m-N+1):m); % region of length N with processed TF-units for all j
+    X_seg = X_seg + eps*randn(size(X_seg)); % to avoid divide by zero
+    Y_seg = Y_seg + eps*randn(size(Y_seg)); % to avoid divide by zero
+    
+    %% first normalize rows (to give \bar{S}_m)
+    XX = X_seg - mean(X_seg.').'*ones(1,N); % normalize rows to zero mean
+    YY = Y_seg - mean(Y_seg.').'*ones(1,N); % normalize rows to zero mean
+    
+    YY = diag(1./sqrt(diag(YY*YY')))*YY; % normalize rows to unit length
+    XX = diag(1./sqrt(diag(XX*XX')))*XX; % normalize rows to unit length
+
+    XX = XX + eps*randn(size(XX)); % to avoid corr.div.by.0
+    YY = YY + eps*randn(size(YY)); % to avoid corr.div.by.0
+
+    %% then normalize columns (to give \check{S}_m)
+    YYY = YY - ones(J,1)*mean(YY); % normalize cols to zero mean
+    XXX = XX - ones(J,1)*mean(XX); % normalize cols to zero mean
+
+    YYY = YYY*diag(1./sqrt(diag(YYY'*YYY))); % normalize cols to unit length
+    XXX = XXX*diag(1./sqrt(diag(XXX'*XXX))); % normalize cols to unit length
+
+    %compute average of col.correlations (by stacking cols)
+    d1(m-N+1) = 1/N*XXX(:).'*YYY(:);
+end
+d = mean(d1);
+
+
+%%
+function  [A cf] = thirdoct(fs, N_fft, numBands, mn)
+%   [A CF] = THIRDOCT(FS, N_FFT, NUMBANDS, MN) returns 1/3 octave band matrix
+%   inputs:
+%       FS:         samplerate
+%       N_FFT:      FFT size
+%       NUMBANDS:   number of bands
+%       MN:         center frequency of first 1/3 octave band
+%   outputs:
+%       A:          octave band matrix
+%       CF:         center frequencies
+
+f               = linspace(0, fs, N_fft+1);
+f               = f(1:(N_fft/2+1));
+k               = 0:(numBands-1);
+cf              = 2.^(k/3)*mn;
+fl              = sqrt((2.^(k/3)*mn).*2.^((k-1)/3)*mn);
+fr              = sqrt((2.^(k/3)*mn).*2.^((k+1)/3)*mn);
+A               = zeros(numBands, length(f));
+
+for i = 1:(length(cf))
+  [a b]                   = min((f-fl(i)).^2);
+  fl(i)                   = f(b);
+  fl_ii                   = b;
+  
+  [a b]                   = min((f-fr(i)).^2);
+  fr(i)                   = f(b);
+  fr_ii                   = b;
+  A(i,fl_ii:(fr_ii-1))	= 1;
+end
+
+rnk         = sum(A, 2);
+numBands  	= find((rnk(2:end)>=rnk(1:(end-1))) & (rnk(2:end)~=0)~=0, 1, 'last' )+1;
+A           = A(1:numBands, :);
+cf          = cf(1:numBands);
+
+%%
+function x_stdft = stdft(x, N, K, N_fft)
+%   X_STDFT = X_STDFT(X, N, K, N_FFT) returns the short-time
+%	hanning-windowed dft of X with frame-size N, overlap K and DFT size
+%   N_FFT. The columns and rows of X_STDFT denote the frame-index and
+%   dft-bin index, respectively.
+
+frames      = 1:K:(length(x)-N);
+x_stdft     = zeros(length(frames), N_fft);
+
+w           = hanning(N);
+x           = x(:);
+
+for i = 1:length(frames)
+  ii              = frames(i):(frames(i)+N-1);
+  x_stdft(i, :) 	= fft(x(ii).*w, N_fft);
+end
+
+%%
+function [x_sil y_sil] = removeSilentFrames(x, y, range, N, K)
+%   [X_SIL Y_SIL] = REMOVESILENTFRAMES(X, Y, RANGE, N, K) X and Y
+%   are segmented with frame-length N and overlap K, where the maximum energy
+%   of all frames of X is determined, say X_MAX. X_SIL and Y_SIL are the
+%   reconstructed signals, excluding the frames, where the energy of a frame
+%   of X is smaller than X_MAX-RANGE
+
+x       = x(:);
+y       = y(:);
+
+frames  = 1:K:(length(x)-N);
+w       = hanning(N);
+msk     = zeros(size(frames));
+
+for j = 1:length(frames)
+  jj      = frames(j):(frames(j)+N-1);
+  msk(j) 	= 20*log10(norm(x(jj).*w)./sqrt(N));
+end
+
+msk     = (msk-max(msk)+range)>0;
+count   = 1;
+
+x_sil   = zeros(size(x));
+y_sil   = zeros(size(y));
+
+for j = 1:length(frames)
+  if msk(j)
+    jj_i            = frames(j):(frames(j)+N-1);
+    jj_o            = frames(count):(frames(count)+N-1);
+    x_sil(jj_o)     = x_sil(jj_o) + x(jj_i).*w;
+    y_sil(jj_o)  	= y_sil(jj_o) + y(jj_i).*w;
+    count           = count+1;
+  end
+end
+
+x_sil = x_sil(1:jj_o(end));
+y_sil = y_sil(1:jj_o(end));
+
+

--- a/tests/test_stoi.py
+++ b/tests/test_stoi.py
@@ -23,6 +23,16 @@ def test_stoi_good_fs():
     assert_allclose(stoi_out, stoi_out_m, atol=ATOL, rtol=RTOL)
 
 
+def test_estoi_good_fs():
+    x = np.random.randn(2*FS, )
+    y = np.random.randn(2*FS, )
+    estoi_out = stoi(x, y, FS, extended=True)
+    x_m = matlab.double(list(x))
+    y_m = matlab.double(list(y))
+    estoi_out_m = eng.estoi(x_m, y_m, float(FS))
+    assert_allclose(estoi_out, estoi_out_m, atol=ATOL, rtol=RTOL)
+
+
 def test_stoi_downsample():
     """ FAILING BECAUSE OF RESAMPLING """
     for fs in [11025, 16000, 22050, 32000, 44100, 48000]:


### PR DESCRIPTION
* Adds kwargument `extended` to `stoi`. Defaults to `False`

* Adds `estoi.m` in `tests/matlab`

* Add a test in `test_stoi.py` for extended STOI at good FS (resampling will have the same effect as in classical STOI)

* Additional tests on the new functions in utils may come