### PR TITLE
Vectorization

### DIFF
--- a/pystoi/stoi.py
+++ b/pystoi/stoi.py
@@ -1,5 +1,4 @@
 import numpy as np
-import scipy
 from resampy import resample
 from . import utils
 
@@ -70,8 +69,9 @@ def stoi(x, y, fs_sig, extended=False):
         [y_tob[:, m - N:m] for m in range(N, x_tob.shape[1] + 1)])
 
     if extended:
-        # placeholder for extended STOI
-        pass
+        x_n = utils.row_col_normalize(x_segments)
+        y_n = utils.row_col_normalize(y_segments)
+        return np.sum(x_n * y_n / N) / x_n.shape[0]
 
     else:
         # Find normalization constants and normalize
@@ -82,7 +82,8 @@ def stoi(x, y, fs_sig, extended=False):
 
         # Clip as described in [1]
         clip_value = 10 ** (-BETA / 20)
-        y_primes = np.minimum(y_segments_normalized, x_segments * (1 + clip_value))
+        y_primes = np.minimum(
+            y_segments_normalized, x_segments * (1 + clip_value))
 
         # Subtract mean vectors
         y_primes = y_primes - np.mean(y_primes, axis=2, keepdims=True)

--- a/pystoi/stoi.py
+++ b/pystoi/stoi.py
@@ -46,41 +46,59 @@ def stoi(x, y, fs_sig, extended=False):
     if x.shape != y.shape:
         raise Exception('x and y should have the same length,' +
                         'found {} and {}'.format(len(x), len(y)))
+
     # Resample is fs_sig is different than fs
     if fs_sig != FS:
         x = resample(x, fs_sig, FS)
         y = resample(y, fs_sig, FS)
+
     # Remove silent frames
     x, y = utils.remove_silent_frames(x, y, DYN_RANGE, N_FRAME, int(N_FRAME/2))
+
     # Take STFT
     x_spec = utils.stft(x, N_FRAME, NFFT, overlap=2).transpose()
     y_spec = utils.stft(y, N_FRAME, NFFT, overlap=2).transpose()
-    # Init third octave band TF representation
-    x_tob = np.zeros((NUMBAND, x_spec.shape[1]))
-    y_tob = np.zeros((NUMBAND, y_spec.shape[1]))
+
     # Apply OB matrix to the spectrograms as in Eq. (1)
-    for i in range(x_tob.shape[1]):
-        x_tob[:, i] = np.sqrt(np.matmul(OBM, np.square(np.abs(x_spec[:, i]))))
-        y_tob[:, i] = np.sqrt(np.matmul(OBM, np.square(np.abs(y_spec[:, i]))))
+    x_tob = np.sqrt(np.matmul(OBM, np.square(np.abs(x_spec))))
+    y_tob = np.sqrt(np.matmul(OBM, np.square(np.abs(y_spec))))
+
+    # Take segments of x_tob, y_tob
+    x_segments = np.array(
+        [x_tob[:, m - N:m] for m in range(N, x_tob.shape[1] + 1)])
+    y_segments = np.array(
+        [y_tob[:, m - N:m] for m in range(N, x_tob.shape[1] + 1)])
 
     if extended:
-        interm_meas = np.zeros((x_tob.shape[1] - N + 1, ))
-    else:
-        interm_meas = np.zeros((NUMBAND, x_tob.shape[1] - N + 1))
-        clip = 10**(-BETA/20)
+        # placeholder for extended STOI
+        pass
 
-    for m in range(N, x_tob.shape[1] + 1):
-        x_seg = x_tob[:, m-N:m]
-        y_seg = y_tob[:, m-N:m]
-        if extended:
-            x_n = utils.row_col_normalize(x_seg)
-            y_n = utils.row_col_normalize(y_seg)
-            interm_meas[m-N] = np.sum(x_n * y_n / N)
-        else:
-            alpha = np.sqrt(np.sum(np.square(x_seg), 1) / np.sum(np.square(y_seg), 1))
-            a_y_seg = np.multiply(y_seg.transpose(), alpha).transpose()
-            for j in range(NUMBAND):
-                Y_prime = np.minimum(a_y_seg[j, :], x_seg[j, :] * (1 + clip))
-                interm_meas[j, m-N] = utils.corr(x_seg[j, :], Y_prime[:])
-    d = np.mean(interm_meas)
-    return d
+    else:
+        # Find normalization constants and normalize
+        normalization_consts = (
+            np.linalg.norm(x_segments, axis=2, keepdims=True) /
+            np.linalg.norm(y_segments, axis=2, keepdims=True))
+        y_segments_normalized = y_segments * normalization_consts
+
+        # Clip as described in [1]
+        clip_value = 10 ** (-BETA / 20)
+        y_primes = np.minimum(y_segments_normalized, x_segments * (1 + clip_value))
+
+        # Subtract mean vectors
+        y_primes = y_primes - np.mean(y_primes, axis=2, keepdims=True)
+        x_segments = x_segments - np.mean(x_segments, axis=2, keepdims=True)
+
+        # Divide by their norms
+        y_primes /= np.linalg.norm(y_primes, axis=2, keepdims=True)
+        x_segments /= np.linalg.norm(x_segments, axis=2, keepdims=True)
+
+        # Find a matrix with entries summing to sum of correlations of vectors
+        correlations_components = y_primes * x_segments
+
+        # J, M as in [1], eq.6
+        J = x_segments.shape[0]
+        M = x_segments.shape[1]
+
+        # Find the mean of all correlations
+        d = np.sum(correlations_components) / (J * M)
+        return d

--- a/pystoi/utils.py
+++ b/pystoi/utils.py
@@ -99,16 +99,6 @@ def remove_silent_frames(x, y, dyn_range, framelen, hop):
     return x_sil, y_sil
 
 
-def corr(x, y):
-    """ Returns correlation coefficient between x and y (1-D)"""
-    new_x = x - np.mean(x)
-    new_x /= np.sqrt(np.sum(np.square(new_x)))
-    new_y = y - np.mean(y)
-    new_y /= np.sqrt(np.sum(np.square(new_y)))
-    rho = np.sum(new_x * new_y)
-    return rho
-
-
 def vect_two_norm(x, axis=-1):
     """ Returns a vectors of norms of the rows of a matrix """
     return np.sum(np.square(x), axis=axis)

--- a/pystoi/utils.py
+++ b/pystoi/utils.py
@@ -100,18 +100,24 @@ def remove_silent_frames(x, y, dyn_range, framelen, hop):
 
 
 def vect_two_norm(x, axis=-1):
-    """ Returns a vectors of norms of the rows of a matrix """
-    return np.sum(np.square(x), axis=axis)
+    """ Returns an array of vectors of norms of the rows of matrices from 3D array """
+    return np.sum(np.square(x), axis=axis, keepdims=True)
 
 
 def row_col_normalize(x):
-    """ Row and column mean and variance normalize a 2D matrix """
+    """ Row and column mean and variance normalize an array of 2D segments """
     # Row mean and variance normalization
     x_normed = x + EPS * np.random.standard_normal(x.shape)
     x_normed -= np.mean(x_normed, axis=-1, keepdims=True)
-    x_normed = np.matmul(np.diag(1. / np.sqrt(vect_two_norm(x_normed))), x_normed)
+    x_inv = 1. / np.sqrt(vect_two_norm(x_normed))
+    x_diags = np.array(
+        [np.diag(x_inv[i].reshape(-1)) for i in range(x_inv.shape[0])])
+    x_normed = np.matmul(x_diags, x_normed)
     # Column mean and variance normalization
     x_normed += + EPS * np.random.standard_normal(x_normed.shape)
-    x_normed -= np.mean(x_normed, axis=0, keepdims=True)
-    x_normed = np.matmul(x_normed, np.diag(1. / np.sqrt(vect_two_norm(x_normed, axis=0))))
+    x_normed -= np.mean(x_normed, axis=1, keepdims=True)
+    x_inv = 1. / np.sqrt(vect_two_norm(x_normed, axis=1))
+    x_diags = np.array(
+        [np.diag(x_inv[i].reshape(-1)) for i in range(x_inv.shape[0])])
+    x_normed = np.matmul(x_normed, x_diags)
     return x_normed


### PR DESCRIPTION
As per contribution request, in this pull request we add vectorisation of a number of computations, specfically:
* Vectorization of nearly all of `utils.remove_silent_frames`
* Vectorization of computations in both classical and extended STOI

There are still a few for loops left in form of list comprehension, though.

As a result, we obtain a nearly 4-fold speed up in computations of classical STOI and 1.5-fold speed up in computations of extended STOI.

We also demonstrate that the results of vectorized implementation agree with the previous one, within tolerance. See documentation for `np.allclose` for details about tolerance threshold.

The minuscule differences in results are most likely due to numerical inaccuracies when performing matrix operations vs doing computations in loops.

See the images below for results and time comparisons.

<img width="494" alt="screen shot 2018-07-18 at 9 27 13 am" src="https://user-images.githubusercontent.com/29800294/42866664-801132be-8a6d-11e8-8c2f-5ebb725d4e4a.png">

<img width="503" alt="screen shot 2018-07-18 at 9 27 40 am" src="https://user-images.githubusercontent.com/29800294/42866667-83ff6dfa-8a6d-11e8-8aba-00ef5c1b66fd.png">

Before merging, please update the README file accordingly.
Thank you!