### PR TITLE
Correct size of removed silence arrays

### DIFF
--- a/pystoi/utils.py
+++ b/pystoi/utils.py
@@ -87,8 +87,9 @@ def remove_silent_frames(x, y, dyn_range, framelen, hop):
     y_frames = y_frames[mask]
 
     # init zero arrays to hold x, y with silent frames removed
-    x_sil = np.zeros((mask.shape[0] - 1) * hop + framelen)
-    y_sil = np.zeros((mask.shape[0] - 1) * hop + framelen)
+    n_sil = (len(x_frames) - 1) * hop + framelen
+    x_sil = np.zeros(n_sil)
+    y_sil = np.zeros(n_sil)
 
     for i in range(x_frames.shape[0]):
         x_sil[range(i * hop, i * hop + framelen)] += x_frames[i, :]


### PR DESCRIPTION
The code was not removing silent frames properly. This was not caught in the unit tests because there are no silent frames in the test data. 

I have confirmed the commit in my own unit tests, but they are based on Octave rather than MATLAB and it would take some work (which I may yet do) to commit them.

The unit test data consists of random numbers. To reproduce the problem and verify the fix, zero out the middle third of the data. Then compare the results of `pystoi` to MATLAB or Octave.