### PR TITLE
Convert test scripts to Octave

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,7 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# Octave workspace file
+octave-workspace
+

--- a/pystoi/stoi.py
+++ b/pystoi/stoi.py
@@ -1,6 +1,6 @@
 import numpy as np
-from resampy import resample
 from . import utils
+from pystoi.utils import resample_oct
 
 # Constant definition
 FS = 10000                          # Sampling frequency
@@ -47,8 +47,8 @@ def stoi(x, y, fs_sig, extended=False):
 
     # Resample is fs_sig is different than fs
     if fs_sig != FS:
-        x = resample(x, fs_sig, FS)
-        y = resample(y, fs_sig, FS)
+        x = resample_oct(x, FS, fs_sig)
+        y = resample_oct(y, FS, fs_sig)
 
     # Remove silent frames
     x, y = utils.remove_silent_frames(x, y, DYN_RANGE, N_FRAME, int(N_FRAME/2))

--- a/pystoi/utils.py
+++ b/pystoi/utils.py
@@ -1,7 +1,52 @@
 import numpy as np
 import scipy
+from scipy.signal import resample_poly
 
 EPS = np.finfo("float").eps
+
+
+def _resample_window_oct(p, q):
+    """Port of Octave code to Python"""
+
+    gcd = np.gcd(p, q)
+    if gcd > 1:
+        p /= gcd
+        q /= gcd
+
+    # Properties of the antialiasing filter
+    log10_rejection = -3.0
+    stopband_cutoff_f = 1 / (2 * max(p, q))
+    roll_off_width = stopband_cutoff_f / 10
+
+    # Determine filter length
+    rejection_dB = -20 * log10_rejection
+    L = np.ceil((rejection_dB - 8) / (28.714 * roll_off_width))
+
+    # Ideal sinc filter
+    t = np.arange(-L, L + 1)
+    ideal_filter = 2 * p * stopband_cutoff_f \
+        * np.sinc(2 * stopband_cutoff_f * t)
+
+    # Determine parameter of Kaiser window
+    if (rejection_dB >= 21) and (rejection_dB <= 50):
+        beta = 0.5842 * (rejection_dB - 21)**0.4 \
+            + 0.07886 * (rejection_dB - 21)
+    elif rejection_dB > 50:
+        beta = 0.1102 * (rejection_dB - 8.7)
+    else:
+        beta = 0.0
+
+    # Apodize ideal filter response
+    h = np.kaiser(2 * L + 1, beta) * ideal_filter
+
+    return h
+
+
+def resample_oct(x, p, q):
+    """Resampler that is compatible with Octave"""
+    h = _resample_window_oct(p, q)
+    window = h / np.sum(h)
+    return resample_poly(x, p, q, window=window)
 
 
 def thirdoct(fs, nfft, num_bands, min_freq):

--- a/tests/octave/applyOBM.m
+++ b/tests/octave/applyOBM.m
@@ -1,0 +1,9 @@
+function X = applyOBM(x, OBM, N_frame, NFFT, NUMBAND)
+
+x_hat = stdft(x, N_frame, N_frame/2, NFFT);
+x_hat = x_hat(:, 1:(NFFT/2+1)).';
+
+X = zeros(NUMBAND, size(x_hat, 2));
+for i = 1:size(x_hat, 2)
+    X(:, i)	= sqrt(OBM*abs(x_hat(:, i)).^2);
+end

--- a/tests/octave/estoi.m
+++ b/tests/octave/estoi.m
@@ -1,0 +1,191 @@
+function d = estoi(x, y, fs_signal)
+%   d = estoi(x, y, fs_signal) returns the output of the extended short-time
+%   objective intelligibility (ESTOI) predictor.
+%
+% Implementation of the Extended Short-Time Objective
+% Intelligibility (ESTOI) predictor, described in Jesper Jensen and
+% Cees H. Taal, "An Algorithm for Predicting the Intelligibility of
+% Speech Masked by Modulated Noise Maskers," IEEE Transactions on
+% Audio, Speech and Language Processing, 2016.
+%
+% Input:
+%        x:         clean reference time domain signal
+%        y:         noisy/processed time domain signal
+%        fs_signal: sampling rate [Hz]
+%
+% Output:
+%        d: intelligibility index
+%
+%
+% Copyright 2016: Aalborg University, Section for Signal and Information Processing.
+% The software is free for non-commercial use.
+% The software comes WITHOUT ANY WARRANTY.
+
+
+if length(x)~=length(y)
+  error('x and y should have the same length');
+end
+
+% initialization
+x               = x(:);                   % clean speech column vector
+y               = y(:);                   % processed speech column vector
+
+fs              = 10000;                  % sample rate of proposed intelligibility measure
+N_frame         = 256;                    % window support
+K               = 512;                    % FFT size
+J               = 15;                     % Number of 1/3 octave bands
+mn              = 150;                    % Center frequency of first 1/3 octave band in Hz.
+[H,fc_thirdoct] = thirdoct(fs, K, J, mn); % Get 1/3 octave band matrix
+N               = 30;                     % Number of frames for intermediate intelligibility measure
+dyn_range       = 40;                     % speech dynamic range
+
+% resample signals if other samplerate is used than fs
+if fs_signal ~= fs
+  x	= resample(x, fs, fs_signal);
+  y 	= resample(y, fs, fs_signal);
+end
+
+% remove silent frames
+[x y] = removeSilentFrames(x, y, dyn_range, N_frame, N_frame/2);
+
+% apply 1/3 octave band TF-decomposition
+x_hat     	= stdft(x, N_frame, N_frame/2, K); % apply short-time DFT to clean speech
+y_hat     	= stdft(y, N_frame, N_frame/2, K); % apply short-time DFT to processed speech
+
+
+x_hat       = x_hat(:, 1:(K/2+1)).'; % take clean single-sided spectrum
+y_hat       = y_hat(:, 1:(K/2+1)).'; % take processed single-sided spectrum
+
+X           = zeros(J, size(x_hat, 2)); % init memory for clean speech 1/3 octave band TF-representation
+Y           = zeros(J, size(y_hat, 2)); % init memory for processed speech 1/3 octave band TF-representation
+
+for i = 1:size(x_hat, 2)
+  X(:, i)	= sqrt(H*abs(x_hat(:, i)).^2); % apply 1/3 octave band filtering
+  Y(:, i)	= sqrt(H*abs(y_hat(:, i)).^2);
+end
+
+% loop all segments of length N and obtain intermediate intelligibility measure for each
+d1 = zeros(length(N:size(X, 2)),1); % init memory for intermediate intelligibility measure
+for m=N:size(X,2)
+    X_seg  	= X(:, (m-N+1):m); % region of length N with clean TF-units for all j
+    Y_seg  	= Y(:, (m-N+1):m); % region of length N with processed TF-units for all j
+    X_seg = X_seg + eps*randn(size(X_seg)); % to avoid divide by zero
+    Y_seg = Y_seg + eps*randn(size(Y_seg)); % to avoid divide by zero
+
+    %% first normalize rows (to give \bar{S}_m)
+    XX = X_seg - mean(X_seg.').'*ones(1,N); % normalize rows to zero mean
+    YY = Y_seg - mean(Y_seg.').'*ones(1,N); % normalize rows to zero mean
+
+    YY = diag(1./sqrt(diag(YY*YY')))*YY; % normalize rows to unit length
+    XX = diag(1./sqrt(diag(XX*XX')))*XX; % normalize rows to unit length
+
+    XX = XX + eps*randn(size(XX)); % to avoid corr.div.by.0
+    YY = YY + eps*randn(size(YY)); % to avoid corr.div.by.0
+
+    %% then normalize columns (to give \check{S}_m)
+    YYY = YY - ones(J,1)*mean(YY); % normalize cols to zero mean
+    XXX = XX - ones(J,1)*mean(XX); % normalize cols to zero mean
+
+    YYY = YYY*diag(1./sqrt(diag(YYY'*YYY))); % normalize cols to unit length
+    XXX = XXX*diag(1./sqrt(diag(XXX'*XXX))); % normalize cols to unit length
+
+    %compute average of col.correlations (by stacking cols)
+    d1(m-N+1) = 1/N*XXX(:).'*YYY(:);
+end
+d = mean(d1);
+
+
+%%
+function  [A cf] = thirdoct(fs, N_fft, numBands, mn)
+%   [A CF] = THIRDOCT(FS, N_FFT, NUMBANDS, MN) returns 1/3 octave band matrix
+%   inputs:
+%       FS:         samplerate
+%       N_FFT:      FFT size
+%       NUMBANDS:   number of bands
+%       MN:         center frequency of first 1/3 octave band
+%   outputs:
+%       A:          octave band matrix
+%       CF:         center frequencies
+
+f               = linspace(0, fs, N_fft+1);
+f               = f(1:(N_fft/2+1));
+k               = 0:(numBands-1);
+cf              = 2.^(k/3)*mn;
+fl              = sqrt((2.^(k/3)*mn).*2.^((k-1)/3)*mn);
+fr              = sqrt((2.^(k/3)*mn).*2.^((k+1)/3)*mn);
+A               = zeros(numBands, length(f));
+
+for i = 1:(length(cf))
+  [a b]                   = min((f-fl(i)).^2);
+  fl(i)                   = f(b);
+  fl_ii                   = b;
+
+  [a b]                   = min((f-fr(i)).^2);
+  fr(i)                   = f(b);
+  fr_ii                   = b;
+  A(i,fl_ii:(fr_ii-1))	= 1;
+end
+
+rnk         = sum(A, 2);
+numBands  	= find((rnk(2:end)>=rnk(1:(end-1))) & (rnk(2:end)~=0)~=0, 1, 'last' )+1;
+A           = A(1:numBands, :);
+cf          = cf(1:numBands);
+
+%%
+function x_stdft = stdft(x, N, K, N_fft)
+%   X_STDFT = X_STDFT(X, N, K, N_FFT) returns the short-time
+%	  hanning-windowed dft of X with frame-size N, overlap K and DFT size
+%   N_FFT. The columns and rows of X_STDFT denote the frame-index and
+%   dft-bin index, respectively.
+
+frames      = 1:K:(length(x)-N);
+x_stdft     = zeros(length(frames), N_fft);
+
+w           = ml_hanning(N);
+x           = x(:);
+
+for i = 1:length(frames)
+  ii              = frames(i):(frames(i)+N-1);
+  x_stdft(i, :) 	= fft(x(ii).*w, N_fft);
+end
+
+%%
+function [x_sil y_sil] = removeSilentFrames(x, y, range, N, K)
+%   [X_SIL Y_SIL] = REMOVESILENTFRAMES(X, Y, RANGE, N, K) X and Y
+%   are segmented with frame-length N and overlap K, where the maximum energy
+%   of all frames of X is determined, say X_MAX. X_SIL and Y_SIL are the
+%   reconstructed signals, excluding the frames, where the energy of a frame
+%   of X is smaller than X_MAX-RANGE
+
+x       = x(:);
+y       = y(:);
+
+frames  = 1:K:(length(x)-N);
+w       = ml_hanning(N);
+msk     = zeros(size(frames));
+
+for j = 1:length(frames)
+  jj      = frames(j):(frames(j)+N-1);
+  msk(j) 	= 20*log10(norm(x(jj).*w)./sqrt(N));
+end
+
+msk     = (msk-max(msk)+range)>0;
+count   = 1;
+
+x_sil   = zeros(size(x));
+y_sil   = zeros(size(y));
+
+for j = 1:length(frames)
+  if msk(j)
+    jj_i            = frames(j):(frames(j)+N-1);
+    jj_o            = frames(count):(frames(count)+N-1);
+    x_sil(jj_o)     = x_sil(jj_o) + x(jj_i).*w;
+    y_sil(jj_o)  	= y_sil(jj_o) + y(jj_i).*w;
+    count           = count+1;
+  end
+end
+
+x_sil = x_sil(1:jj_o(end));
+y_sil = y_sil(1:jj_o(end));
+
+

--- a/tests/octave/ml_hanning.m
+++ b/tests/octave/ml_hanning.m
@@ -1,0 +1,5 @@
+function w = ml_hanning(M)
+    %   Compute a Hann window compatible with the MATLAB `hanning` function
+    w = .5 * (1 - cos(2 * pi * (1:M)'/double(M + 1)));
+end
+

--- a/tests/octave/removeSilentFrames.m
+++ b/tests/octave/removeSilentFrames.m
@@ -1,0 +1,32 @@
+function [x_sil, y_sil] = removeSilentFrames(x, y, range, N, K)
+
+x       = x(:);
+y       = y(:);
+
+frames  = 1:K:(length(x)-N);
+w       = ml_hanning(N);
+msk     = zeros(size(frames));
+
+for j = 1:length(frames)
+    jj      = frames(j):(frames(j)+N-1);
+    msk(j) 	= 20*log10(norm(x(jj).*w)./sqrt(N));
+end
+
+msk     = (msk-max(msk)+range)>0;
+count   = 1;
+
+x_sil   = zeros(size(x));
+y_sil   = zeros(size(y));
+
+for j = 1:length(frames)
+    if msk(j)
+        jj_i            = frames(j):(frames(j)+N-1);
+        jj_o            = frames(count):(frames(count)+N-1);
+        x_sil(jj_o)     = x_sil(jj_o) + x(jj_i).*w;
+        y_sil(jj_o)  	= y_sil(jj_o) + y(jj_i).*w;
+        count           = count+1;
+    end
+end
+
+x_sil = x_sil(1:jj_o(end));
+y_sil = y_sil(1:jj_o(end));

--- a/tests/octave/stdft.m
+++ b/tests/octave/stdft.m
@@ -1,0 +1,12 @@
+function x_stdft = stdft(x, N, K, N_fft)
+
+frames      = 1:K:(length(x)-N);
+x_stdft     = zeros(length(frames), N_fft);
+
+w           = ml_hanning(N);
+x           = x(:);
+
+for i = 1:length(frames)
+    ii              = frames(i):(frames(i)+N-1);
+	x_stdft(i, :) 	= fft(x(ii).*w, N_fft);
+end

--- a/tests/octave/stoi.m
+++ b/tests/octave/stoi.m
@@ -1,0 +1,188 @@
+function d = stoi(x, y, fs_signal)
+%   d = stoi(x, y, fs_signal) returns the output of the short-time
+%   objective intelligibility (STOI) measure described in [1, 2], where x
+%   and y denote the clean and processed speech, respectively, with sample
+%   rate fs_signal in Hz. The output d is expected to have a monotonic
+%   relation with the subjective speech-intelligibility, where a higher d
+%   denotes better intelligible speech. See [1, 2] for more details.
+%
+%   References:
+%      [1] C.H.Taal, R.C.Hendriks, R.Heusdens, J.Jensen 'A Short-Time
+%      Objective Intelligibility Measure for Time-Frequency Weighted Noisy
+%      Speech', ICASSP 2010, Texas, Dallas.
+%
+%      [2] C.H.Taal, R.C.Hendriks, R.Heusdens, J.Jensen 'An Algorithm for
+%      Intelligibility Prediction of Time-Frequency Weighted Noisy Speech',
+%      IEEE Transactions on Audio, Speech, and Language Processing, 2011.
+%
+%
+% Copyright 2009: Delft University of Technology, Signal & Information
+% Processing Lab. The software is free for non-commercial use. This program
+% comes WITHOUT ANY WARRANTY.
+%
+%
+%
+% Updates:
+% 2011-04-26 Using the more efficient 'taa_corr' instead of 'corr'
+
+if length(x)~=length(y)
+    error('x and y should have the same length');
+end
+
+% initialization
+x           = x(:);                             % clean speech column vector
+y           = y(:);                             % processed speech column vector
+
+fs          = 10000;                            % sample rate of proposed intelligibility measure
+N_frame    	= 256;                              % window support
+K           = 512;                              % FFT size
+J           = 15;                               % Number of 1/3 octave bands
+mn          = 150;                              % Center frequency of first 1/3 octave band in Hz.
+H           = thirdoct(fs, K, J, mn);           % Get 1/3 octave band matrix
+N           = 30;                               % Number of frames for intermediate intelligibility measure (Length analysis window)
+Beta        = -15;                           	% lower SDR-bound
+dyn_range   = 40;                               % speech dynamic range
+
+% resample signals if other samplerate is used than fs
+if fs_signal ~= fs
+    x	= resample(x, fs, fs_signal);
+    y 	= resample(y, fs, fs_signal);
+end
+
+% remove silent frames
+[x y] = removeSilentFrames(x, y, dyn_range, N_frame, N_frame/2);
+
+% apply 1/3 octave band TF-decomposition
+x_hat     	= stdft(x, N_frame, N_frame/2, K); 	% apply short-time DFT to clean speech
+y_hat     	= stdft(y, N_frame, N_frame/2, K); 	% apply short-time DFT to processed speech
+
+x_hat       = x_hat(:, 1:(K/2+1)).';         	% take clean single-sided spectrum
+y_hat       = y_hat(:, 1:(K/2+1)).';        	% take processed single-sided spectrum
+
+X           = zeros(J, size(x_hat, 2));         % init memory for clean speech 1/3 octave band TF-representation
+Y           = zeros(J, size(y_hat, 2));         % init memory for processed speech 1/3 octave band TF-representation
+
+for i = 1:size(x_hat, 2)
+    X(:, i)	= sqrt(H*abs(x_hat(:, i)).^2);      % apply 1/3 octave bands as described in Eq.(1) [1]
+    Y(:, i)	= sqrt(H*abs(y_hat(:, i)).^2);
+end
+
+% loop al segments of length N and obtain intermediate intelligibility measure for all TF-regions
+d_interm  	= zeros(J, length(N:size(X, 2)));                               % init memory for intermediate intelligibility measure
+c           = 10^(-Beta/20);                                                % constant for clipping procedure
+
+for m = N:size(X, 2)
+    X_seg  	= X(:, (m-N+1):m);                                              % region with length N of clean TF-units for all j
+    Y_seg  	= Y(:, (m-N+1):m);                                              % region with length N of processed TF-units for all j
+    alpha   = sqrt(sum(X_seg.^2, 2)./sum(Y_seg.^2, 2));                     % obtain scale factor for normalizing processed TF-region for all j
+    aY_seg 	= Y_seg.*repmat(alpha, [1 N]);                               	% obtain \alpha*Y_j(n) from Eq.(2) [1]
+    for j = 1:J
+      	Y_prime             = min(aY_seg(j, :), X_seg(j, :)+X_seg(j, :)*c); % apply clipping from Eq.(3)
+        d_interm(j, m-N+1)  = taa_corr(X_seg(j, :).', Y_prime(:));          % obtain correlation coeffecient from Eq.(4) [1]
+    end
+end
+
+d = mean(d_interm(:));                                                      % combine all intermediate intelligibility measures as in Eq.(4) [1]
+
+%%
+function  [A cf] = thirdoct(fs, N_fft, numBands, mn)
+%   [A CF] = THIRDOCT(FS, N_FFT, NUMBANDS, MN) returns 1/3 octave band matrix
+%   inputs:
+%       FS:         samplerate
+%       N_FFT:      FFT size
+%       NUMBANDS:   number of bands
+%       MN:         center frequency of first 1/3 octave band
+%   outputs:
+%       A:          octave band matrix
+%       CF:         center frequencies
+
+f               = linspace(0, fs, N_fft+1);
+f               = f(1:(N_fft/2+1));
+k               = 0:(numBands-1);
+cf              = 2.^(k/3)*mn;
+fl              = sqrt((2.^(k/3)*mn).*2.^((k-1)/3)*mn);
+fr              = sqrt((2.^(k/3)*mn).*2.^((k+1)/3)*mn);
+A               = zeros(numBands, length(f));
+
+for i = 1:(length(cf))
+    [a b]                   = min((f-fl(i)).^2);
+    fl(i)                   = f(b);
+    fl_ii                   = b;
+
+	[a b]                   = min((f-fr(i)).^2);
+    fr(i)                   = f(b);
+    fr_ii                   = b;
+    A(i,fl_ii:(fr_ii-1))	= 1;
+end
+
+rnk         = sum(A, 2);
+numBands  	= find((rnk(2:end)>=rnk(1:(end-1))) & (rnk(2:end)~=0)~=0, 1, 'last' )+1;
+A           = A(1:numBands, :);
+cf          = cf(1:numBands);
+
+%%
+function x_stdft = stdft(x, N, K, N_fft)
+%   X_STDFT = X_STDFT(X, N, K, N_FFT) returns the short-time
+%	hanning-windowed dft of X with frame-size N, overlap K and DFT size
+%   N_FFT. The columns and rows of X_STDFT denote the frame-index and
+%   dft-bin index, respectively.
+
+frames      = 1:K:(length(x)-N);
+x_stdft     = zeros(length(frames), N_fft);
+
+w           = ml_hanning(N);
+x           = x(:);
+
+for i = 1:length(frames)
+    ii              = frames(i):(frames(i)+N-1);
+	x_stdft(i, :) 	= fft(x(ii).*w, N_fft);
+end
+
+%%
+function [x_sil y_sil] = removeSilentFrames(x, y, range, N, K)
+%   [X_SIL Y_SIL] = REMOVESILENTFRAMES(X, Y, RANGE, N, K) X and Y
+%   are segmented with frame-length N and overlap K, where the maximum energy
+%   of all frames of X is determined, say X_MAX. X_SIL and Y_SIL are the
+%   reconstructed signals, excluding the frames, where the energy of a frame
+%   of X is smaller than X_MAX-RANGE
+
+x       = x(:);
+y       = y(:);
+
+frames  = 1:K:(length(x)-N);
+w       = ml_hanning(N);
+msk     = zeros(size(frames));
+
+for j = 1:length(frames)
+    jj      = frames(j):(frames(j)+N-1);
+    msk(j) 	= 20*log10(norm(x(jj).*w)./sqrt(N));
+end
+
+msk     = (msk-max(msk)+range)>0;
+count   = 1;
+
+x_sil   = zeros(size(x));
+y_sil   = zeros(size(y));
+
+for j = 1:length(frames)
+    if msk(j)
+        jj_i            = frames(j):(frames(j)+N-1);
+        jj_o            = frames(count):(frames(count)+N-1);
+        x_sil(jj_o)     = x_sil(jj_o) + x(jj_i).*w;
+        y_sil(jj_o)  	= y_sil(jj_o) + y(jj_i).*w;
+        count           = count+1;
+    end
+end
+
+x_sil = x_sil(1:jj_o(end));
+y_sil = y_sil(1:jj_o(end));
+
+%%
+function rho = taa_corr(x, y)
+%   RHO = TAA_CORR(X, Y) Returns correlation coeffecient between column
+%   vectors x and y. Gives same results as 'corr' from statistics toolbox.
+xn    	= x-mean(x);
+xn  	= xn/sqrt(sum(xn.^2));
+yn   	= y-mean(y);
+yn    	= yn/sqrt(sum(yn.^2));
+rho   	= sum(xn.*yn);

--- a/tests/octave/thirdoct.m
+++ b/tests/octave/thirdoct.m
@@ -1,0 +1,25 @@
+function  [A cf] = thirdoct(fs, N_fft, numBands, mn)
+
+f               = linspace(0, fs, N_fft+1);
+f               = f(1:(N_fft/2+1));
+k               = 0:(numBands-1);
+cf              = 2.^(k/3)*mn;
+fl              = sqrt((2.^(k/3)*mn).*2.^((k-1)/3)*mn);
+fr              = sqrt((2.^(k/3)*mn).*2.^((k+1)/3)*mn);
+A               = zeros(numBands, length(f));
+
+for i = 1:(length(cf))
+    [a b]                   = min((f-fl(i)).^2);
+    fl(i)                   = f(b);
+    fl_ii                   = b;
+
+	[a b]                   = min((f-fr(i)).^2);
+    fr(i)                   = f(b);
+    fr_ii                   = b;
+    A(i,fl_ii:(fr_ii-1))	= 1;
+end
+
+rnk         = sum(A, 2);
+numBands  	= find((rnk(2:end)>=rnk(1:(end-1))) & (rnk(2:end)~=0)~=0, 1, 'last' )+1;
+A           = A(1:numBands, :);
+cf          = cf(1:numBands);

--- a/tests/test_python_octave.py
+++ b/tests/test_python_octave.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+""" Unit tests for Octave """
+import numpy as np
+from numpy.testing import assert_allclose
+from oct2py import octave
+import pytest
+import scipy
+
+from pystoi.stoi import FS, N_FRAME, NFFT
+from pystoi.utils import resample_oct
+
+ATOL = 1e-5
+
+
+def test_hanning():
+    """ Compare scipy and Matlab hanning window.
+
+        Matlab returns a N+2 size window without first and last samples.
+        A custom Octave function has been written to mimic this
+        behavior."""
+    hanning = scipy.hanning(N_FRAME+2)[1:-1]
+    hanning_m = np.squeeze(octave.feval('octave/ml_hanning.m', N_FRAME))
+    assert_allclose(hanning, hanning_m, atol=ATOL)
+
+
+def test_fft():
+    """ Compare FFT to Octave. """
+    x = np.random.randn(NFFT)
+    fft_m = np.squeeze(octave.fft(x))
+    fft_m = fft_m[:NFFT//2+1]
+    fft = np.fft.rfft(x, n=NFFT)
+    assert_allclose(fft, fft_m, atol=ATOL)
+
+
+def test_resample():
+    """ Compare Octave and SciPy resampling.
+
+    Both packages use polyphase resampling with a Kaiser window. We use
+    the window designed by Octave in the SciPy resampler."""
+    RTOL = 1e-4
+
+    for fs in [8000, 11025, 16000, 22050, 32000, 44100, 48000]:
+        x = np.random.randn(2 * fs)
+        octave.eval('pkg load signal')
+        x_m, h = octave.resample(x, float(FS), float(fs), nout=2)
+        h = np.squeeze(h)
+        x_m = np.squeeze(x_m)
+        x_r = resample_oct(x, FS, fs)
+        assert_allclose(x_r, x_m, atol=ATOL, rtol=RTOL)
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])

--- a/tests/test_stoi_octave.py
+++ b/tests/test_stoi_octave.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import numpy as np
+from numpy.testing import assert_allclose
+from oct2py import octave
+import pytest
+
+from pystoi.stoi import FS, stoi
+
+RTOL = 1e-6
+ATOL = 1e-6
+
+
+def test_stoi_good_fs():
+    """ Test STOI at sampling frequency of 10kHz. """
+    x = np.random.randn(2 * FS)
+    y = np.random.randn(2 * FS)
+    stoi_out = stoi(x, y, FS)
+    stoi_out_m = octave.feval('octave/stoi.m', x, y, float(FS))
+    assert_allclose(stoi_out, stoi_out_m, atol=ATOL, rtol=RTOL)
+
+
+def test_estoi_good_fs():
+    """ Test extended STOI at sampling frequency of 10kHz. """
+    x = np.random.randn(2 * FS)
+    y = np.random.randn(2 * FS)
+    estoi_out = stoi(x, y, FS, extended=True)
+    estoi_out_m = octave.feval('octave/estoi.m', x, y, float(FS))
+    assert_allclose(estoi_out, estoi_out_m, atol=ATOL, rtol=RTOL)
+
+
+def test_stoi_downsample():
+    """ Test STOI at sampling frequency below 10 kHz. """
+    for fs in [11025, 16000, 22050, 32000, 44100, 48000]:
+        x = np.random.randn(2 * fs)
+        y = np.random.randn(2 * fs)
+        octave.eval('pkg load signal')
+        stoi_out = stoi(x, y, fs)
+        stoi_out_m = octave.feval('octave/stoi.m', x, y, float(fs))
+        assert_allclose(stoi_out, stoi_out_m, atol=ATOL, rtol=RTOL)
+
+
+def test_stoi_upsample():
+    """ Test STOI at sampling frequency above 10 kHz. """
+    for fs in [8000]:
+        x = np.random.randn(2 * fs)
+        y = np.random.randn(2 * fs)
+        octave.eval('pkg load signal')
+        stoi_out = stoi(x, y, fs)
+        stoi_out_m = octave.feval('octave/stoi.m', x, y, float(fs))
+        assert_allclose(stoi_out, stoi_out_m, atol=ATOL, rtol=RTOL)
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])

--- a/tests/test_utils_octave.py
+++ b/tests/test_utils_octave.py
@@ -26,7 +26,7 @@ def test_thirdoct():
 
 def test_stdft():
     """Test stdft by comparing to Octave"""
-    x = np.random.randn(2 * FS, )
+    x = np.random.randn(2 * FS)
     spec_m = octave.feval('octave/stdft.m',
                           x, float(N_FRAME), float(N_FRAME/2), float(NFFT))
     spec_m = spec_m[:, 0:(NFFT // 2 + 1)].transpose()
@@ -38,8 +38,8 @@ def test_removesf():
     """Test remove_silent_frames by comparing to Octave"""
 
     # Initialize
-    x = np.random.randn(2 * FS, )
-    y = np.random.randn(2 * FS, )
+    x = np.random.randn(2 * FS)
+    y = np.random.randn(2 * FS)
 
     # Add silence segment
     silence = np.zeros(3 * NFFT, )
@@ -62,7 +62,7 @@ def test_apply_OBM():
     obm_m, _ = octave.feval('octave/thirdoct.m',
                             float(FS), float(NFFT), float(NUMBAND),
                             float(MINFREQ), nout=2)
-    x = np.random.randn(2 * FS, )
+    x = np.random.randn(2 * FS)
     x_tob_m = octave.feval('octave/applyOBM',
                            x, obm_m, float(N_FRAME), float(NFFT),
                            float(NUMBAND))

--- a/tests/test_utils_octave.py
+++ b/tests/test_utils_octave.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Test utilities based on Octave"""
+import numpy as np
+from numpy.testing import assert_allclose
+from oct2py import octave
+import pytest
+
+from pystoi.stoi import DYN_RANGE, FS, MINFREQ, N_FRAME, NFFT, NUMBAND, OBM
+from pystoi.utils import remove_silent_frames, stft, thirdoct
+
+ATOL = 1e-5
+
+
+def test_thirdoct():
+    """Test thirdoct by comparing to Octave"""
+    obm_m, cf_m = octave.feval('octave/thirdoct.m',
+                               float(FS), float(NFFT), float(NUMBAND),
+                               float(MINFREQ), nout=2)
+    obm, cf = thirdoct(FS, NFFT, NUMBAND, MINFREQ)
+    obm_m = np.array(obm_m)
+    cf_m = np.array(cf_m).transpose().squeeze()
+    assert_allclose(obm, obm_m, atol=ATOL)
+    assert_allclose(cf, cf_m, atol=ATOL)
+
+
+def test_stdft():
+    """Test stdft by comparing to Octave"""
+    x = np.random.randn(2 * FS, )
+    spec_m = octave.feval('octave/stdft.m',
+                          x, float(N_FRAME), float(N_FRAME/2), float(NFFT))
+    spec_m = spec_m[:, 0:(NFFT // 2 + 1)].transpose()
+    spec = stft(x, N_FRAME, NFFT, overlap=2).transpose()
+    assert_allclose(spec, spec_m, atol=ATOL)
+
+
+def test_removesf():
+    """Test remove_silent_frames by comparing to Octave"""
+
+    # Initialize
+    x = np.random.randn(2 * FS, )
+    y = np.random.randn(2 * FS, )
+
+    # Add silence segment
+    silence = np.zeros(3 * NFFT, )
+    x = np.concatenate([x[:FS], silence, x[FS:]])
+    y = np.concatenate([y[:FS], silence, y[FS:]])
+    xs, ys = remove_silent_frames(x, y, DYN_RANGE, N_FRAME, N_FRAME // 2)
+    xs_m, ys_m = octave.feval('octave/removeSilentFrames.m',
+                              x, y, float(DYN_RANGE),
+                              float(N_FRAME),
+                              float(N_FRAME / 2),
+                              nout=2)
+    xs_m = np.squeeze(xs_m)
+    ys_m = np.squeeze(ys_m)
+    assert_allclose(xs, xs_m, atol=ATOL)
+    assert_allclose(ys, ys_m, atol=ATOL)
+
+
+def test_apply_OBM():
+    """Test apply_OBM by comparing to Octave"""
+    obm_m, _ = octave.feval('octave/thirdoct.m',
+                            float(FS), float(NFFT), float(NUMBAND),
+                            float(MINFREQ), nout=2)
+    x = np.random.randn(2 * FS, )
+    x_tob_m = octave.feval('octave/applyOBM',
+                           x, obm_m, float(N_FRAME), float(NFFT),
+                           float(NUMBAND))
+    x_tob_m = np.array(x_tob_m)
+    x_spec = stft(x, N_FRAME, NFFT, overlap=2).transpose()
+    x_tob = np.zeros((NUMBAND, x_spec.shape[1]))
+    for i in range(x_tob.shape[1]):
+        x_tob[:, i] = np.sqrt(np.matmul(OBM, np.square(np.abs(x_spec[:, i]))))
+    assert_allclose(x_tob, x_tob_m, atol=ATOL)
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])


### PR DESCRIPTION
Here's a first cut at creating test scripts to work with Octave instead of Matlab. Let me know if you agree with this approach and I can convert the other scripts. It's pretty straightforward.

The tests in this script pass if my other pull request is merged. The test `test_removesf` should fail without that pull request, but I've only tested that in a somewhat different environment.

**What's changed**

1. The Matlab `.m` files have been copied to a new directory `octave` and modified slightly: the Hann window is defined slightly differently in Matlab and Octave so a compatible function `ml_hanning` was created and the Octave functions call that.

2. The file `test_utils.py` was copied to `test_utils_octave.py` which was modified to call out to the Octave code instead of Matlab.

3. Other minor changes were made to `test_utils_octave.py` to make it pylint/flake8 clean.

**Requirements**

1. Install [GNU Octave](https://www.gnu.org/software/octave/)

2. Install [oct2py](https://pypi.org/project/oct2py/)

3. cd to the `test` directory and run `test_utils_octave.py` (It needs to be run from that directory.)