### PR TITLE
WTF is this 57.8% of MATLAB

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/* linguist-vendored=true


### PR DESCRIPTION
At first glance, I thought this was a Matlab project.. with a py* name, a python related description, and setup.py  :confounded:??
Ahh, no, it's just for tests.
This PR sets the `linguist-vendored` attribute for the `tests` directory. This tells Github to not use the `tests` directory for the project's language stats.

More info on the `linguist-vendored` attribute: https://github.com/github/linguist#overrides