### PR TITLE
Introduce a faster overlap_and_add method

### DIFF
--- a/tests/test_overlap_and_add.py
+++ b/tests/test_overlap_and_add.py
@@ -1,0 +1,27 @@
+import numpy as np
+from numpy.testing import assert_allclose
+
+from pystoi.stoi import N_FRAME
+from pystoi.utils import _overlap_and_add
+
+
+def test_OLA_vectorisation():
+    """test the vectorised overlap_and_add comparing to the old one"""
+
+    def old_overlap_and_app(x_frames, framelen, hop):
+        # init zero arrays to hold x, y with silent frames removed
+        n_sil = (len(x_frames) - 1) * hop + framelen
+        x_sil = np.zeros(n_sil)
+        for i in range(x_frames.shape[0]):
+            x_sil[range(i * hop, i * hop + framelen)] += x_frames[i, :]
+        return x_sil
+
+    # Initialize
+    x = np.random.randn(1000 * N_FRAME)
+    # Add silence segment
+    silence = np.zeros(10 * N_FRAME)
+    x = np.concatenate([x[: 500 * N_FRAME], silence, x[500 * N_FRAME :]])
+    x = x.reshape([-1, N_FRAME])
+    xs = old_overlap_and_app(x, N_FRAME, N_FRAME // 2)
+    xs_vectorise = _overlap_and_add(x, N_FRAME, N_FRAME // 2)
+    assert_allclose(xs, xs_vectorise)

--- a/tests/test_overlap_and_add.py
+++ b/tests/test_overlap_and_add.py
@@ -8,11 +8,10 @@ from pystoi.utils import _overlap_and_add
 def test_OLA_vectorisation():
     """test the vectorised overlap_and_add comparing to the old one"""
 
-    def old_overlap_and_app(x_frames, framelen, hop):
-        # init zero arrays to hold x, y with silent frames removed
-        n_sil = (len(x_frames) - 1) * hop + framelen
-        x_sil = np.zeros(n_sil)
-        for i in range(x_frames.shape[0]):
+    def old_overlap_and_app(x_frames, hop):
+        num_frames, framelen = x_frames.shape
+        x_sil = np.zeros((num_frames - 1) * hop + framelen)
+        for i in range(num_frames):
             x_sil[range(i * hop, i * hop + framelen)] += x_frames[i, :]
         return x_sil
 
@@ -22,6 +21,6 @@ def test_OLA_vectorisation():
     silence = np.zeros(10 * N_FRAME)
     x = np.concatenate([x[: 500 * N_FRAME], silence, x[500 * N_FRAME :]])
     x = x.reshape([-1, N_FRAME])
-    xs = old_overlap_and_app(x, N_FRAME, N_FRAME // 2)
-    xs_vectorise = _overlap_and_add(x, N_FRAME, N_FRAME // 2)
+    xs = old_overlap_and_app(x, N_FRAME // 2)
+    xs_vectorise = _overlap_and_add(x, N_FRAME // 2)
     assert_allclose(xs, xs_vectorise)


### PR DESCRIPTION
This PR introduces a new overlap_and_add method, inspired by the one implemented in tensorflow (https://github.com/tensorflow/tensorflow/blob/v2.7.0/tensorflow/python/ops/signal/reconstruction_ops.py#L30-L167) , that is ~50 times faster than the previous one on a 30-seconds audio because it vectorises the code instead of making a for loop.